### PR TITLE
Execute determinations for empty values

### DIFF
--- a/content-management/domain/usecase/content/util/modify-helper.ts
+++ b/content-management/domain/usecase/content/util/modify-helper.ts
@@ -61,7 +61,13 @@ class ModifyHelper<T> {
                         return Result.error(validationResult.getMessage());
                 }
 
-                this.logger.debug(`No value provided for field "%s".`, contentField.name);
+                fieldValue = contentField.contentFieldDefinition.executeDeterminations(fieldValue);
+                finalContent[contentField.name] = fieldValue;
+
+                if (fieldValue || fieldValue === 0)
+                    this.logger.debug(`Setting value "%s" for field "%s".`, fieldValue, contentField.name);
+                else 
+                    this.logger.debug(`No value provided for field "%s".`, contentField.name);
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thuya/framework",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Thuya CMS - Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Determinations should be executed even for empty values. It makes it possible to define fields for `createdAt` or `changedAt`.